### PR TITLE
Setup Investment Sorting Functionality

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["clientExtensions"]
+  previewFeatures = ["clientExtensions", "orderByNulls"]
 }
 
 datasource db {
@@ -42,6 +42,7 @@ model Company {
   ticker      String
   sector      Sector?
   industry    String?
+  netAssetSum Float
   investment  Investment[]
   description String?
   ESG         ESG[]

--- a/src/components/Selects/Select.tsx
+++ b/src/components/Selects/Select.tsx
@@ -132,7 +132,7 @@ export const Select: FC<SelectProps> = ({
       </button>
 
       {isOpen && (
-        <div className="absolute top-14 left-0 w-full rounded-md border-[0.5px] border-solid border-cobalt p-5 shadow-md">
+        <div className="absolute top-14 left-0 w-full rounded-md border-[0.5px] border-solid border-cobalt bg-white p-5 shadow-md">
           {isSearchable && (
             <div className="relative mb-5">
               <input

--- a/src/components/Selects/Select.tsx
+++ b/src/components/Selects/Select.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { FC } from 'react'
-import { ChevronDownIcon } from '@heroicons/react/24/solid'
+import { ChevronDownIcon, MagnifyingGlassIcon } from '@heroicons/react/24/solid'
 
 type Options = string[] | Record<string, string[]>
 
@@ -9,7 +9,14 @@ interface SelectProps {
   options: Options
   onClose?: () => void
   onOpen?: () => void
-  onChange?: (value: string[]) => void
+  // onChange?: (value: string[]) => void
+  // type?: 'on-change' | 'on-apply'
+  updateControl?: {
+    type: 'on-change' | 'on-apply'
+    cb: (value: string[]) => void
+  }
+  isSearchable?: boolean
+  containerHeight?: string
 }
 
 /**
@@ -25,11 +32,14 @@ export const Select: FC<SelectProps> = ({
   text,
   onClose,
   onOpen,
-  onChange,
+  updateControl,
   options,
+  isSearchable = false,
+  containerHeight,
 }) => {
   const [isOpen, setIsOpen] = useState(false)
   const [selected, setSelected] = useState<string[]>([])
+  const [searchQuery, setSearchQuery] = useState('')
 
   useEffect(() => {
     if (isOpen) {
@@ -58,7 +68,10 @@ export const Select: FC<SelectProps> = ({
     }
 
     setSelected(currentSelected)
-    onChange?.(currentSelected)
+
+    if (updateControl?.type === 'on-change') {
+      updateControl?.cb(currentSelected)
+    }
   }
 
   /**
@@ -83,8 +96,22 @@ export const Select: FC<SelectProps> = ({
     }
 
     setSelected(currentSelected)
-    onChange?.(currentSelected)
+
+    if (updateControl?.type === 'on-change') {
+      updateControl?.cb(currentSelected)
+    }
   }
+
+  const handleApply = () => {
+    if (updateControl?.type !== 'on-apply') {
+      return
+    }
+
+    updateControl.cb(selected)
+  }
+
+  const handleSearchFilter = (value: string) =>
+    searchQuery !== '' ? value.includes(searchQuery) : true
 
   return (
     <div className="relative ml-10 w-72">
@@ -106,42 +133,72 @@ export const Select: FC<SelectProps> = ({
 
       {isOpen && (
         <div className="absolute top-14 left-0 w-full rounded-md border-[0.5px] border-solid border-cobalt p-5 shadow-md">
-          {isStringArray(options) ? (
-            <ul className="flex flex-col gap-4">
-              {options.map((option) => (
-                <li key={option} className="flex items-center text-black">
-                  <span>{option}</span>
-                  <input
-                    onChange={() => handleChange(option)}
-                    type="checkbox"
-                    className="ml-[auto] scale-125"
-                    checked={selected.includes(option)}
-                  />
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <ul className="flex flex-col gap-5">
-              {Object.entries(options).map(([key, value]) => (
-                <li key={key} className="text-black">
-                  <span className="text-xl">{key}</span>
-                  <ul className="mt-2 flex flex-col gap-2">
-                    {value.map((option) => (
-                      <li key={option} className="flex items-center text-black">
-                        <span>{option}</span>
-                        <input
-                          onChange={() => handleGroupChange(`${key}-${option}`)}
-                          type="checkbox"
-                          className="ml-[auto] scale-125"
-                          checked={selected.includes(`${key}-${option}`)}
-                        />
-                      </li>
-                    ))}
-                  </ul>
-                </li>
-              ))}
-            </ul>
+          {isSearchable && (
+            <div className="relative mb-5">
+              <input
+                onChange={(e) => setSearchQuery(e.currentTarget.value)}
+                type="text"
+                className="relative h-7 w-full border border-solid border-black px-3 py-1 pl-8 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                placeholder="Search..."
+              />
+              <MagnifyingGlassIcon className="absolute top-1.5 left-2 h-4 w-4" />
+            </div>
           )}
+          <div
+            className={`${
+              containerHeight ? `max-h-[${containerHeight}]` : 'max-h-fit'
+            } w-full overflow-x-visible overflow-y-scroll p-0`}
+          >
+            {isStringArray(options) ? (
+              <ul className="m-auto flex w-11/12 flex-col gap-4">
+                {options.filter(handleSearchFilter).map((option) => (
+                  <li key={option} className="flex items-center text-black">
+                    <span>{option}</span>
+                    <input
+                      onChange={() => handleChange(option)}
+                      type="checkbox"
+                      className="ml-[auto] scale-125"
+                      checked={selected.includes(option)}
+                    />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <ul className="m-auto flex w-11/12 flex-col gap-5">
+                {Object.entries(options).map(([key, value]) => (
+                  <li key={key} className="text-black">
+                    <span className="text-xl">{key}</span>
+                    <ul className="mt-2 flex flex-col gap-2">
+                      {value.filter(handleSearchFilter).map((option) => (
+                        <li
+                          key={option}
+                          className="flex items-center text-black"
+                        >
+                          <span>{option}</span>
+                          <input
+                            onChange={() =>
+                              handleGroupChange(`${key}-${option}`)
+                            }
+                            type="checkbox"
+                            className="ml-[auto] scale-125"
+                            checked={selected.includes(`${key}-${option}`)}
+                          />
+                        </li>
+                      ))}
+                    </ul>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {updateControl?.type === 'on-apply' && (
+              <button
+                className="m-[auto] mt-5 flex w-9/12 justify-center rounded-full bg-black text-sm text-white"
+                onClick={handleApply}
+              >
+                Apply
+              </button>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/Selects/Select.tsx
+++ b/src/components/Selects/Select.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react'
+import type { FC } from 'react'
+import { ChevronDownIcon } from '@heroicons/react/24/solid'
+
+type Options = string[] | Record<string, string[]>
+
+interface SelectProps {
+  text: string
+  options: Options
+  onClose?: () => void
+  onOpen?: () => void
+  onChange?: (value: string[]) => void
+}
+
+/**
+ * Type narrows the options to a string array
+ *
+ * @param options The options to check
+ * @returns true if the options are a string array, false otherwise
+ */
+const isStringArray = (options: Options): options is string[] =>
+  Array.isArray(options)
+
+export const Select: FC<SelectProps> = ({
+  text,
+  onClose,
+  onOpen,
+  onChange,
+  options,
+}) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [selected, setSelected] = useState<string[]>([])
+
+  useEffect(() => {
+    if (isOpen) {
+      onOpen?.()
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) {
+      onClose?.()
+    }
+  }, [isOpen])
+
+  /**
+   * Updates the selected state and calls the onChange callback
+   *
+   * @param e The event object
+   */
+  const handleChange = (option: string) => {
+    let currentSelected = [...selected]
+
+    if (selected.includes(option)) {
+      currentSelected = currentSelected.filter((item) => item !== option)
+    } else {
+      currentSelected.push(option)
+    }
+
+    setSelected(currentSelected)
+    onChange?.(currentSelected)
+  }
+
+  /**
+   * Updates the selected state and only allows 1 option to be selected from each key group
+   *
+   * @param option The option to select in the form of key-value
+   */
+  const handleGroupChange = (option: string) => {
+    let currentSelected = [...selected]
+
+    const [key, _value] = option.split('-')
+
+    if (selected.includes(option)) {
+      currentSelected = currentSelected.filter((item) => item !== option)
+    } else if (selected.some((item) => item.split('-')[0] === key)) {
+      currentSelected = currentSelected.filter(
+        (item) => item.split('-')[0] !== key,
+      )
+      currentSelected.push(option)
+    } else {
+      currentSelected.push(option)
+    }
+
+    setSelected(currentSelected)
+    onChange?.(currentSelected)
+  }
+
+  return (
+    <div className="relative ml-10 w-72">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="float-right flex h-10 w-fit items-center justify-center overflow-hidden rounded-full border  border-solid border-darkTeal"
+      >
+        <span className="mx-5 flex h-full w-fit items-center justify-center bg-white">
+          <span className="text-black">{text}</span>
+        </span>
+        <span className="flex h-full items-center justify-center bg-black px-3">
+          <ChevronDownIcon
+            className={`ease h-5 w-5 transform fill-white stroke-white duration-300 ${
+              isOpen ? 'rotate-180' : ''
+            }`}
+          />
+        </span>
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-14 left-0 w-full rounded-md border-[0.5px] border-solid border-cobalt p-5 shadow-md">
+          {isStringArray(options) ? (
+            <ul className="flex flex-col gap-4">
+              {options.map((option) => (
+                <li key={option} className="flex items-center text-black">
+                  <span>{option}</span>
+                  <input
+                    onChange={() => handleChange(option)}
+                    type="checkbox"
+                    className="ml-[auto] scale-125"
+                    checked={selected.includes(option)}
+                  />
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <ul className="flex flex-col gap-5">
+              {Object.entries(options).map(([key, value]) => (
+                <li key={key} className="text-black">
+                  <span className="text-xl">{key}</span>
+                  <ul className="mt-2 flex flex-col gap-2">
+                    {value.map((option) => (
+                      <li key={option} className="flex items-center text-black">
+                        <span>{option}</span>
+                        <input
+                          onChange={() => handleGroupChange(`${key}-${option}`)}
+                          type="checkbox"
+                          className="ml-[auto] scale-125"
+                          checked={selected.includes(`${key}-${option}`)}
+                        />
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Select

--- a/src/components/Selects/Select.tsx
+++ b/src/components/Selects/Select.tsx
@@ -102,6 +102,9 @@ export const Select: FC<SelectProps> = ({
     }
   }
 
+  /**
+   * Called when the apply option is clicked and validates whether this dropdown should trigger
+   */
   const handleApply = () => {
     if (updateControl?.type !== 'on-apply') {
       return
@@ -110,6 +113,12 @@ export const Select: FC<SelectProps> = ({
     updateControl.cb(selected)
   }
 
+  /**
+   * Determines whether a value should be in the filter or not
+   *
+   * @param value The value in consideration
+   * @returns true if value includes searchQuery or searchQuery is empty, else false
+   */
   const handleSearchFilter = (value: string) =>
     searchQuery !== '' ? value.includes(searchQuery) : true
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,6 +7,7 @@ import NavBar from './Nav/NavBar'
 import PrimaryButton from './Buttons/PrimaryButton'
 import ToTopButton from './Buttons/ToTopButton'
 import Carousel from './Displays/Carousel/Carousel'
+import Select from './Selects/Select'
 
 export {
   AuthButton,
@@ -18,4 +19,5 @@ export {
   PrimaryButton,
   ToTopButton,
   Carousel,
+  Select,
 }

--- a/src/pages/investments/index.tsx
+++ b/src/pages/investments/index.tsx
@@ -129,7 +129,7 @@ const Home: FC = () => {
           type: 'on-apply',
           cb: setSelectedSortKeys,
         }}
-        isSearchable={false}
+        isSearchable={true}
       />
     </div>
   )

--- a/src/pages/investments/index.tsx
+++ b/src/pages/investments/index.tsx
@@ -125,7 +125,11 @@ const Home: FC = () => {
           'Environment Grade': ['low to high', 'high to low'],
           'Net Asset Sum': ['low to high', 'high to low'],
         }}
-        onChange={setSelectedSortKeys}
+        updateControl={{
+          type: 'on-apply',
+          cb: setSelectedSortKeys,
+        }}
+        isSearchable={false}
       />
     </div>
   )

--- a/src/pages/investments/index.tsx
+++ b/src/pages/investments/index.tsx
@@ -31,16 +31,6 @@ const extractSortyByQueryKey = (
 const Home: FC = () => {
   const [selectedSortKeys, setSelectedSortKeys] = useState<string[]>([])
 
-  useEffect(() => {
-    const refetchData = async () => {
-      await refetch()
-    }
-
-    refetchData().catch((err) => {
-      console.error(err)
-    })
-  }, [selectedSortKeys])
-
   const limit = 5
   const {
     fetchNextPage,
@@ -67,6 +57,16 @@ const Home: FC = () => {
       cacheTime: 0,
     },
   )
+
+  useEffect(() => {
+    const refetchData = async () => {
+      await refetch()
+    }
+
+    refetchData().catch((err) => {
+      console.error(err)
+    })
+  }, [selectedSortKeys])
 
   return (
     <div>

--- a/src/pages/investments/index.tsx
+++ b/src/pages/investments/index.tsx
@@ -1,19 +1,72 @@
+import { useEffect, useState } from 'react'
 import type { FC } from 'react'
 
+import { Select } from '../../components'
 import { api } from '../../utils/api'
 
+const extractSortyByQueryKey = (
+  key: 'Net Asset Sum' | 'Environment Grade',
+  selectedSorts: string[],
+) => {
+  const selectedSort = selectedSorts.find((item) => {
+    const [field, _order] = item.split('-')
+    return field === key
+  })
+
+  if (!selectedSort) {
+    return null
+  }
+
+  const [_field, order] = selectedSort.split('-')
+
+  if (order === 'low to high') {
+    return 'asc'
+  } else if (order === 'high to low') {
+    return 'desc'
+  }
+
+  return null
+}
+
 const Home: FC = () => {
+  const [selectedSortKeys, setSelectedSortKeys] = useState<string[]>([])
+
+  useEffect(() => {
+    const refetchData = async () => {
+      await refetch()
+    }
+
+    refetchData().catch((err) => {
+      console.error(err)
+    })
+  }, [selectedSortKeys])
+
   const limit = 5
-  const { fetchNextPage, isLoading, hasNextPage, isFetchingNextPage, data } =
-    api.company.getInvestments.useInfiniteQuery(
-      {
-        limit: limit,
-      },
-      {
-        getNextPageParam: (lastPage) => lastPage.nextCursor,
-        refetchOnWindowFocus: false,
-      },
-    )
+  const {
+    fetchNextPage,
+    isLoading,
+    hasNextPage,
+    isFetchingNextPage,
+    data,
+    refetch,
+  } = api.company.getInvestments.useInfiniteQuery(
+    {
+      limit: limit,
+      sortByNetAssestSum: extractSortyByQueryKey(
+        'Net Asset Sum',
+        selectedSortKeys,
+      ),
+      sortByEnvGrade: extractSortyByQueryKey(
+        'Environment Grade',
+        selectedSortKeys,
+      ),
+    },
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+      refetchOnWindowFocus: false,
+      cacheTime: 0,
+    },
+  )
 
   return (
     <div>
@@ -65,6 +118,15 @@ const Home: FC = () => {
       >
         Load More
       </button>
+
+      <Select
+        text="sort by"
+        options={{
+          'Environment Grade': ['low to high', 'high to low'],
+          'Net Asset Sum': ['low to high', 'high to low'],
+        }}
+        onChange={setSelectedSortKeys}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

This creates a generic Select component that is styled has customizable text. Note for @zorazrr: this will need to be made a little more extensible to allow for other selects/dropdowns to use it. If this extensibility is not required, we can rename the file to be specific to the sort filter (but that seems like an excessive component then in terms of the component's functionality). 

The PR also added new keys to the `company` route. 

```tsx
sortByEnvGrade: z.string().nullish(),
sortByNetAssestSum: z.string().nullish(),
```

These keys are used in ordering as follows

```tsx
 const items = await ctx.prisma.company.findMany({
        orderBy: {
          netAssetSum: extractSortOrder(input.sortByNetAssestSum)
            ? input.sortByNetAssestSum
            : undefined,
        },
        include: {
          ESG: {
            orderBy: {
              environment_grade: extractSortOrder(input.sortByEnvGrade)
                ? input.sortByEnvGrade
                : undefined,
            },
            select: {
              environment_grade: true,
            },
          },
        },
        take: limit + 1,
        cursor: cursor ? { id: cursor } : undefined,
      })
```
This endpoint had to be refactored to use the `include` syntax in order to all for relational ordering with the `ESG` table. 

Resolved #36 

## Important Notices

1. A `cacheTime: 0` was added to the infinite query hook. This allows the curser to be reset each time a new sort query is set. It does not appear trivially possible to persist the curser between distinct sort queries. At best, we could cache a specific selection of sort queries to persist the curser specific to the sorts selected. 
2. See note about `Select` extensibility. 

## Changes

- Creates a generic dropdown component
- Refactors the investment query to allow for proper ordering

## Screenshots

<img width="357" alt="Screen Shot 2023-03-07 at 12 28 44 AM" src="https://user-images.githubusercontent.com/66758185/223339045-38848d3d-b0a5-41ae-8bb3-d04872b79248.png">

