### PR TITLE
Set up Skeleton Structure for Company Details Page

### DIFF
--- a/src/pages/company/[id].tsx
+++ b/src/pages/company/[id].tsx
@@ -1,6 +1,9 @@
 import type { Investment } from '@prisma/client'
+import { Spinner } from 'flowbite-react'
+import { useRouter } from 'next/router'
 
-import InvestmentTable from '../../components/Table/InvestmentTable'
+import { HighlightedTitle, InvestmentTable } from '../../components'
+import { api } from '../../utils/api'
 
 const TEST_INVESTMENTS: Investment[] = [
   {
@@ -39,11 +42,51 @@ const TEST_INVESTMENTS: Investment[] = [
 ]
 
 const Company = () => {
+  const companyId = (useRouter().query.id as string) ?? ''
+
+  const { data, isLoading, isError } = api.company.getCompany.useQuery(
+    { id: companyId },
+    { refetchOnWindowFocus: false, enabled: !!companyId },
+  )
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center px-12">
+        <Spinner color="info" />
+      </div>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="flex flex-col items-center px-12">
+        <HighlightedTitle
+          title="Company Not Found"
+          size="large"
+          color="clementine"
+        />
+      </div>
+    )
+  }
+
   return (
-    <>
+    <div className="mb-20 flex flex-col px-12">
+      <div className="flex flex-col items-center">
+        <HighlightedTitle title={data.name} size="large" color="clementine" />
+      </div>
+      <HighlightedTitle
+        title="Investment Visualizations"
+        size="medium"
+        color="brightTeal"
+      />
+      <HighlightedTitle
+        title="Investment Details"
+        size="medium"
+        color="brightTeal"
+      />
       <InvestmentTable investments={TEST_INVESTMENTS} />
       <button>Load more</button>
-    </>
+    </div>
   )
 }
 

--- a/src/server/api/routers/company.ts
+++ b/src/server/api/routers/company.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 
 import { createTRPCRouter, publicProcedure } from '../trpc'
@@ -13,6 +14,26 @@ const extractSortOrder = (
 }
 
 export const companyRouter = createTRPCRouter({
+  getCompany: publicProcedure
+    .input(
+      z.object({
+        id: z.string(),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      const company = await ctx.prisma.company.findUnique({
+        where: {
+          id: input.id,
+        },
+      })
+      if (!company) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Company not found',
+        })
+      }
+      return company
+    }),
   getCompanies: publicProcedure
     .input(
       z.object({


### PR DESCRIPTION
## Summary

Set up skeleton structure for Company Details Page 

## Changes

- Created new tRPC procedure `getCompany` that retrieves information for a single company by id 
- Added overall outline and title to company details page 

## Screenshots
<img width="955" alt="image" src="https://user-images.githubusercontent.com/61670566/227973488-f6952e2a-ee4e-4f4c-a48b-3c89ce09ff9b.png">

## Requests / Responses
<img width="454" alt="image" src="https://user-images.githubusercontent.com/61670566/227973614-24b6c5b4-4a18-4878-8830-2eaf28b4aec8.png">
