### PR TITLE
Embed Climate Clock Widget

### DIFF
--- a/src/components/Displays/ClimateClock/ClimateClock.tsx
+++ b/src/components/Displays/ClimateClock/ClimateClock.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react'
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      'climate-clock': React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >
+    }
+  }
+}
+
+const ClimateClock = () => {
+  const [isMounted, setIsMounted] = useState(false)
+
+  useEffect(() => {
+    if (!isMounted) {
+      const script = document.createElement('script')
+      script.src = 'https://climateclock.world/widget-v2.js'
+      script.async = true
+      script.onload = () => {
+        const climateClock = document.createElement('climate-clock')
+        const container = document.getElementById('climate-clock-container')
+        if (container) {
+          container.appendChild(climateClock)
+          setIsMounted(true)
+        } else {
+          console.error(
+            'Could not find element with ID "climate-clock-container"',
+          )
+        }
+      }
+      document.body.appendChild(script)
+    }
+
+    return () => {
+      const climateClock = document.querySelector('climate-clock')
+      if (climateClock) {
+        climateClock.remove()
+      }
+    }
+  }, [isMounted])
+
+  return (
+    <>
+      <div
+        id="climate-clock-container"
+        className="mx-auto w-[79rem] items-center"
+      ></div>
+    </>
+  )
+}
+
+export default ClimateClock

--- a/src/components/Displays/ClimateClock/ClimateClock.tsx
+++ b/src/components/Displays/ClimateClock/ClimateClock.tsx
@@ -1,48 +1,11 @@
-import React, { useEffect, useState } from 'react'
+import Script from 'next/script'
 
 const ClimateClock = () => {
-  const [isMounted, setIsMounted] = useState(false)
-
-  /*
-   * This useEffect checks to see if the Climate Clock widget is truthy (whether or not it has already been rendered)
-   * before loading the script and appending the climate clock widget to the container.
-   */
-  useEffect(() => {
-    if (!isMounted) {
-      // Declare a custom script element and load the Climate Clock script.
-      const script = document.createElement('script')
-      script.src = 'https://climateclock.world/widget-v2.js'
-      script.async = true
-      script.onload = () => {
-        const climateClock = document.createElement('climate-clock')
-        const container = document.getElementById('climate-clock-container')
-        if (container) {
-          container.appendChild(climateClock)
-          setIsMounted(true)
-        } else {
-          console.error(
-            'Could not find element with ID "climate-clock-container"',
-          )
-        }
-      }
-      document.body.appendChild(script)
-    }
-
-    return () => {
-      const climateClock = document.querySelector('climate-clock')
-      // If the component has already been loaded, remove the duplicate.
-      if (climateClock) {
-        climateClock.remove()
-      }
-    }
-  }, [isMounted])
-
   return (
     <>
-      <div
-        id="climate-clock-container"
-        className="mx-auto w-5/6 items-center"
-      ></div>
+      <div id="climate-clock-container" className="mx-auto w-5/6 items-center">
+        <Script src="https://climateclock.world/widget-v2.js" async />
+      </div>
     </>
   )
 }

--- a/src/components/Displays/ClimateClock/ClimateClock.tsx
+++ b/src/components/Displays/ClimateClock/ClimateClock.tsx
@@ -1,17 +1,5 @@
 import React, { useEffect, useState } from 'react'
 
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace JSX {
-    interface IntrinsicElements {
-      'climate-clock': React.DetailedHTMLProps<
-        React.HTMLAttributes<HTMLElement>,
-        HTMLElement
-      >
-    }
-  }
-}
-
 const ClimateClock = () => {
   const [isMounted, setIsMounted] = useState(false)
 

--- a/src/components/Displays/ClimateClock/ClimateClock.tsx
+++ b/src/components/Displays/ClimateClock/ClimateClock.tsx
@@ -3,8 +3,13 @@ import React, { useEffect, useState } from 'react'
 const ClimateClock = () => {
   const [isMounted, setIsMounted] = useState(false)
 
+  /*
+   * This useEffect checks to see if the Climate Clock widget is truthy (whether or not it has already been rendered)
+   * before loading the script and appending the climate clock widget to the container.
+   */
   useEffect(() => {
     if (!isMounted) {
+      // Declare a custom script element and load the Climate Clock script.
       const script = document.createElement('script')
       script.src = 'https://climateclock.world/widget-v2.js'
       script.async = true
@@ -25,6 +30,7 @@ const ClimateClock = () => {
 
     return () => {
       const climateClock = document.querySelector('climate-clock')
+      // If the component has already been loaded, remove the duplicate.
       if (climateClock) {
         climateClock.remove()
       }
@@ -35,7 +41,7 @@ const ClimateClock = () => {
     <>
       <div
         id="climate-clock-container"
-        className="mx-auto w-[79rem] items-center"
+        className="mx-auto w-5/6 items-center"
       ></div>
     </>
   )

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,6 +20,7 @@ import FinanceBrushChart from './Charts/FinanceBrushChart'
 // Displays
 import ListItem from './Displays/ListItem'
 import Carousel from './Displays/Carousel/Carousel'
+import ClimateClock from './Displays/ClimateClock/ClimateClock'
 // Accordions
 import RequestAccordion from './Accordions/RequestAccordion'
 import FinancialCaseAccordion from './Accordions/FinancialCaseAccordion'
@@ -74,4 +75,5 @@ export {
   DataCard,
   CompanyDetailsAccordion,
   EnergyRadialChart,
+  ClimateClock,
 }

--- a/src/pages/fossil-fuel/index.tsx
+++ b/src/pages/fossil-fuel/index.tsx
@@ -4,6 +4,7 @@ import { PrimaryNavBar, ToTopButton } from '../../components'
 import { ContentWrapper } from '../../utils/content'
 import { FinancialCase } from '../../sections'
 import type { CaseEntry } from '../../types'
+import ClimateClock from '../../components/Displays/ClimateClock/ClimateClock'
 
 export const getServerSideProps = async () => {
   const contentClient = new ContentWrapper()
@@ -27,6 +28,7 @@ const FossilFuelPage: FC<FossilFuelProps> = ({ caseEntries }) => {
       <div id="financialCase" className="pt-20">
         <FinancialCase entries={caseEntries} />
       </div>
+      <ClimateClock />
     </>
   )
 }

--- a/src/pages/fossil-fuel/index.tsx
+++ b/src/pages/fossil-fuel/index.tsx
@@ -1,10 +1,9 @@
 import type { FC } from 'react'
 
-import { PrimaryNavBar, ToTopButton } from '../../components'
+import { PrimaryNavBar, ToTopButton, ClimateClock } from '../../components'
 import { ContentWrapper } from '../../utils/content'
 import { FinancialCase } from '../../sections'
 import type { CaseEntry } from '../../types'
-import ClimateClock from '../../components/Displays/ClimateClock/ClimateClock'
 
 export const getServerSideProps = async () => {
   const contentClient = new ContentWrapper()


### PR DESCRIPTION
## Summary

Embedding the climate clock widget take 2 ! 
Closes #100 

## Changes

- Delete `// eslint-disable-next-line @typescript-eslint/no-namespace ` in order to declare a namespace for the <climate-clock /> custom component
- use the useEffect hook to load the script asynchronously and wait for it to load before rendering the climate-clock
 component

## Screenshots
![image](https://user-images.githubusercontent.com/61480751/232153236-1b81c129-4abf-4eed-8db6-0d9de208d7dc.png)
