### PR TITLE
Case Accordion Adjustments

### DIFF
--- a/src/components/Accordions/CaseAccordion.tsx
+++ b/src/components/Accordions/CaseAccordion.tsx
@@ -6,17 +6,16 @@ import {
   ArrowUpRightIcon,
 } from '@heroicons/react/24/solid'
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer'
-import { INLINES } from '@contentful/rich-text-types'
+import { BLOCKS, INLINES } from '@contentful/rich-text-types'
 import type {
   Block,
   Inline,
 } from '@contentful/rich-text-types/dist/types/types'
 import clsx from 'clsx'
 
-import { ReadMoreButton } from '../index'
 import type { CaseEntry } from '../../types'
 
-const FinancialCaseAccordion: FC<{ content: CaseEntry }> = ({ content }) => {
+const CaseAccordion: FC<{ content: CaseEntry }> = ({ content }) => {
   const [open, setOpen] = useState(false)
   const handleOpen = () => {
     setOpen(!open)
@@ -24,6 +23,15 @@ const FinancialCaseAccordion: FC<{ content: CaseEntry }> = ({ content }) => {
 
   const contentfulOptions = {
     renderNode: {
+      [BLOCKS.DOCUMENT]: (node: any, children: any) => {
+        return (
+          <>
+            {!open && Array.isArray(children) && children.length > 0
+              ? children[0]
+              : children}
+          </>
+        )
+      },
       [INLINES.HYPERLINK]: (node: Block | Inline, children: any) => {
         const url =
           'uri' in node.data && typeof node.data.uri == 'string'
@@ -70,23 +78,10 @@ const FinancialCaseAccordion: FC<{ content: CaseEntry }> = ({ content }) => {
           <PlusIcon className="mr-10 inline h-9 w-7 stroke-current stroke-2" />
         )}
       </button>
-      {open && (
-        <div className="font-regular mx-12 flex flex-col gap-2 border-t-2 border-cobalt pt-6 font-inter text-base text-black">
-          {documentToReactComponents(content.details, contentfulOptions)}
-          <div className="flex pt-[7px] pb-5">
-            {content.url && (
-              <ReadMoreButton
-                isOpen={false}
-                handleOpen={() => {
-                  return
-                }}
-                link={content.url}
-              />
-            )}
-          </div>
-        </div>
-      )}
+      <div className="font-regular mx-12 flex flex-col gap-2 border-t-2 border-cobalt pt-6 pb-9 font-inter text-base text-black">
+        {documentToReactComponents(content.details, contentfulOptions)}
+      </div>
     </div>
   )
 }
-export default FinancialCaseAccordion
+export default CaseAccordion

--- a/src/components/Accordions/CaseAccordion.tsx
+++ b/src/components/Accordions/CaseAccordion.tsx
@@ -57,11 +57,7 @@ const CaseAccordion: FC<{ content: CaseEntry }> = ({ content }) => {
       <button
         onClick={handleOpen}
         className={clsx(
-          'flex w-full flex-row items-center justify-between bg-lightBlue px-4 py-2 lg:flex-row',
-          {
-            '-mb-[2px] rounded-t-lg': open,
-            'rounded-lg': !open,
-          },
+          '-mb-[0.125rem] flex w-full flex-row items-center justify-between rounded-t-lg bg-lightBlue px-4 py-2 lg:flex-row',
         )}
       >
         <p
@@ -78,7 +74,15 @@ const CaseAccordion: FC<{ content: CaseEntry }> = ({ content }) => {
           <PlusIcon className="mr-10 inline h-9 w-7 stroke-current stroke-2" />
         )}
       </button>
-      <div className="font-regular mx-12 flex flex-col gap-2 border-t-2 border-cobalt pt-6 pb-9 font-inter text-base text-black">
+      <div
+        className={clsx(
+          'font-regular flex flex-col gap-2 border-t-[0.125rem] border-cobalt pt-6 pb-9 font-inter text-base text-black',
+          {
+            'mx-[47px]': open,
+            'mx-12': !open,
+          },
+        )}
+      >
         {documentToReactComponents(content.details, contentfulOptions)}
       </div>
     </div>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -22,7 +22,7 @@ import ListItem from './Displays/ListItem'
 import Carousel from './Displays/Carousel/Carousel'
 // Accordions
 import RequestAccordion from './Accordions/RequestAccordion'
-import FinancialCaseAccordion from './Accordions/FinancialCaseAccordion'
+import CaseAccordion from './Accordions/CaseAccordion'
 import CompanyDetailsAccordion from './Accordions/CompanyDetailsAccordion'
 // Nav
 import PrimaryNavBar from './Nav/PrimaryNavBar'
@@ -67,7 +67,7 @@ export {
   ESGTag,
   NetAssetTag,
   Tag,
-  FinancialCaseAccordion,
+  CaseAccordion,
   ToolTip,
   FuelRadialChart,
   EmissionBarChart,

--- a/src/sections/fossil-fuel/FinancialCase.tsx
+++ b/src/sections/fossil-fuel/FinancialCase.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react'
 
-import { HighlightedTitle, FinancialCaseAccordion } from '../../components'
+import { HighlightedTitle, CaseAccordion } from '../../components'
 import type { CaseEntry } from '../../types'
 
 const FinancialCase: FC<{ entries: CaseEntry[] }> = ({ entries }) => {
@@ -13,7 +13,7 @@ const FinancialCase: FC<{ entries: CaseEntry[] }> = ({ entries }) => {
       />
       {entries.map((entry, index) => (
         <div key={index}>
-          <FinancialCaseAccordion content={entry} />
+          <CaseAccordion content={entry} />
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary

This changes the Financial Case Accordion component into a general Case Accordion component. It modifies the behavior so instead of displaying no body text when closed, the accordion only displays the first paragraph of body text.

The Contentful content has also been updated to reflect the changes made.

Closes #127

## Changes

- Renames FinancialCaseAccordion to CaseAccordion
- Changes closed behavior of CaseAccordion 

## Screenshots

![image](https://user-images.githubusercontent.com/111911351/232667664-ddf4bdaa-dc2c-4a2e-abc1-d9dd86c5300c.png)
![image](https://user-images.githubusercontent.com/111911351/232667718-36430f94-d292-4b41-b34b-6d450641eaf8.png)
