### PR TITLE
Fix Delete Many Users Procedure

### DIFF
--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -39,6 +39,19 @@ export const userRouter = createTRPCRouter({
           message: 'Failed to delete users',
         })
       }
+      const deleteWhitelist = await ctx.prisma.whitelistedUser.deleteMany({
+        where: {
+          userId: {
+            in: input.ids,
+          },
+        },
+      })
+      if (!deleteWhitelist) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to delete user from whitelist',
+        })
+      }
     }),
 
   updateUserEmailPreference: protectedProcedure


### PR DESCRIPTION
## Summary

Because of the change in #126, the `deleteManyUsers` procedure does not cascade anymore. 
This is a temporary fix to manually go through each item in the DB to delete until we find a better way to replace `whitelisteduser` schema. 