### PR TITLE
Display All Users on Admin Table

### DIFF
--- a/src/components/Selects/InviteAdminBar.tsx
+++ b/src/components/Selects/InviteAdminBar.tsx
@@ -4,7 +4,11 @@ import { useState } from 'react'
 import { PrimaryButton } from '..'
 import { api } from '../../utils/api'
 
-const InviteAdminBar: FC = () => {
+interface InviteAdminBarProps {
+  refetch: () => Promise<any>
+}
+
+const InviteAdminBar: FC<InviteAdminBarProps> = ({ refetch }) => {
   const isValidEmail = (email: string) => {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
     return emailRegex.test(email)
@@ -13,6 +17,10 @@ const InviteAdminBar: FC = () => {
 
   const mutation = api.user.addWhitelistedUser.useMutation({
     retry: false,
+    async onSuccess() {
+      setEmail('')
+      await refetch()
+    },
   })
 
   const handleSubmit = (event?: React.SyntheticEvent) => {

--- a/src/components/Table/AdminListTable.tsx
+++ b/src/components/Table/AdminListTable.tsx
@@ -11,6 +11,10 @@ const delUserTextStyle = (deletePressed: boolean) =>
     'text-black': !deletePressed,
   })
 
+function isLoggedInUser(user: User | WhitelistedUser): user is User {
+  return (user as WhitelistedUser).userId === undefined
+}
+
 interface AdminTableProps {
   users: (User | WhitelistedUser)[] | undefined
   editEnabled: boolean
@@ -53,6 +57,7 @@ const AdminListTable: FC<AdminTableProps> = ({
         {users?.map((user, num) => {
           const deletePressed = tempDeleted.indexOf(user.id) > -1
           const checkClicked = tempChecked.indexOf(user.id) > -1
+          const isFullUser = isLoggedInUser(user)
           return (
             <div
               key={num}
@@ -61,7 +66,7 @@ const AdminListTable: FC<AdminTableProps> = ({
               <div className="mt-4 flex w-10/12 flex-row items-center gap-1 border-b-[1px] border-darkGray pb-4 pl-6">
                 <p className={delUserTextStyle(deletePressed)}>{user.email}</p>
                 <p className={delUserTextStyle(deletePressed)}>
-                  {(user as User).name || 'N/A'}
+                  {isFullUser ? user.name : 'N/A'}
                 </p>
                 <p
                   className={clsx('body-normal basis-1/6', {
@@ -69,22 +74,18 @@ const AdminListTable: FC<AdminTableProps> = ({
                     'text-medGray': !deletePressed,
                   })}
                 >
-                  {(user as User).createdAt?.toLocaleDateString() || 'N/A'}
+                  {isFullUser ? user.createdAt?.toLocaleDateString() : 'N/A'}
                 </p>
                 <div className="flex basis-1/6 flex-col items-center">
                   <Checkbox
                     onClick={() => onCheck(user.id)}
                     className="h-6 w-6"
-                    disabled={
-                      !editEnabled ||
-                      deletePressed ||
-                      (user as WhitelistedUser).userId !== undefined
-                    }
+                    disabled={!editEnabled || deletePressed || !isFullUser}
                     checked={
-                      (user as WhitelistedUser).userId === undefined &&
+                      isFullUser &&
                       (editEnabled && checkClicked
-                        ? !(user as User).shouldEmail
-                        : (user as User).shouldEmail)
+                        ? !user.shouldEmail
+                        : user.shouldEmail)
                     }
                   ></Checkbox>
                 </div>

--- a/src/components/Table/AdminListTable.tsx
+++ b/src/components/Table/AdminListTable.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react'
-import type { User } from '@prisma/client'
+import type { User, WhitelistedUser } from '@prisma/client'
 import { Checkbox } from 'flowbite-react'
 import clsx from 'clsx'
 import { TrashIcon, ArrowUturnLeftIcon } from '@heroicons/react/24/outline'
@@ -12,7 +12,7 @@ const delUserTextStyle = (deletePressed: boolean) =>
   })
 
 interface AdminTableProps {
-  users: User[] | undefined
+  users: (User | WhitelistedUser)[] | undefined
   editEnabled: boolean
   onTrash: (id: string) => void
   onUndo: (id: string) => void
@@ -60,24 +60,31 @@ const AdminListTable: FC<AdminTableProps> = ({
             >
               <div className="mt-4 flex w-10/12 flex-row items-center gap-1 border-b-[1px] border-darkGray pb-4 pl-6">
                 <p className={delUserTextStyle(deletePressed)}>{user.email}</p>
-                <p className={delUserTextStyle(deletePressed)}>{user.name}</p>
+                <p className={delUserTextStyle(deletePressed)}>
+                  {(user as User).name || 'N/A'}
+                </p>
                 <p
                   className={clsx('body-normal basis-1/6', {
                     'text-lightGray': deletePressed,
                     'text-medGray': !deletePressed,
                   })}
                 >
-                  {user.createdAt.toLocaleDateString()}
+                  {(user as User).createdAt?.toLocaleDateString() || 'N/A'}
                 </p>
                 <div className="flex basis-1/6 flex-col items-center">
                   <Checkbox
                     onClick={() => onCheck(user.id)}
                     className="h-6 w-6"
-                    disabled={!editEnabled || deletePressed}
+                    disabled={
+                      !editEnabled ||
+                      deletePressed ||
+                      (user as WhitelistedUser).userId !== undefined
+                    }
                     checked={
-                      editEnabled && checkClicked
-                        ? !user.shouldEmail
-                        : user.shouldEmail
+                      (user as WhitelistedUser).userId === undefined &&
+                      (editEnabled && checkClicked
+                        ? !(user as User).shouldEmail
+                        : (user as User).shouldEmail)
                     }
                   ></Checkbox>
                 </div>

--- a/src/pages/admin/management.tsx
+++ b/src/pages/admin/management.tsx
@@ -28,6 +28,14 @@ const AdminAdminPage: FC = () => {
     },
   })
 
+  const deleteWhitelistedUsersMutation =
+    api.user.deleteManyWhitelistedUsers.useMutation({
+      async onSuccess() {
+        setUsersToDelete([])
+        await refetch()
+      },
+    })
+
   const updateEmailsMutation = api.user.updateUserEmailPreference.useMutation({
     async onSuccess() {
       setUsersEmailUpdate([])
@@ -45,6 +53,7 @@ const AdminAdminPage: FC = () => {
 
   const handleUpdateUsers = () => {
     updateEmailsMutation.mutate({ ids: usersEmailUpdate })
+    deleteWhitelistedUsersMutation.mutate({ ids: usersToDelete })
     deleteUsersMutation.mutate({ ids: usersToDelete })
     setEdit(false)
   }
@@ -134,7 +143,7 @@ const AdminAdminPage: FC = () => {
                 color="clementine"
               />
             </div>
-            <InviteAdminBar />
+            <InviteAdminBar refetch={refetch} />
           </div>
         </div>
       </>

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -26,19 +26,6 @@ export const userRouter = createTRPCRouter({
   deleteManyUsers: protectedProcedure
     .input(z.object({ ids: z.array(z.string()) }))
     .mutation(async ({ input, ctx }) => {
-      const deleteUsers = await ctx.prisma.user.deleteMany({
-        where: {
-          id: {
-            in: input.ids,
-          },
-        },
-      })
-      if (!deleteUsers) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Failed to delete users',
-        })
-      }
       const deleteWhitelist = await ctx.prisma.whitelistedUser.deleteMany({
         where: {
           userId: {
@@ -52,8 +39,37 @@ export const userRouter = createTRPCRouter({
           message: 'Failed to delete user from whitelist',
         })
       }
+      const deleteUsers = await ctx.prisma.user.deleteMany({
+        where: {
+          id: {
+            in: input.ids,
+          },
+        },
+      })
+      if (!deleteUsers) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to delete users',
+        })
+      }
     }),
-
+  deleteManyWhitelistedUsers: protectedProcedure
+    .input(z.object({ ids: z.array(z.string()) }))
+    .mutation(async ({ input, ctx }) => {
+      const deleteWhitelist = await ctx.prisma.whitelistedUser.deleteMany({
+        where: {
+          id: {
+            in: input.ids,
+          },
+        },
+      })
+      if (!deleteWhitelist) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to delete user from whitelist',
+        })
+      }
+    }),
   updateUserEmailPreference: protectedProcedure
     .input(z.object({ ids: z.array(z.string()) }))
     .mutation(async ({ input, ctx }) => {
@@ -94,9 +110,43 @@ export const userRouter = createTRPCRouter({
     }),
 
   getAllUsers: protectedProcedure.query(async ({ ctx }) => {
-    const users = await ctx.prisma.user.findMany()
-    return users
+    const users = await ctx.prisma.whitelistedUser.findMany()
+
+    const fullUsers = users.map(async (wuser) => {
+      if (!wuser.userId) {
+        return wuser
+      }
+      return (
+        (await ctx.prisma.user.findUnique({
+          where: {
+            id: wuser.userId,
+          },
+        })) || wuser
+      )
+    })
+
+    const promises = await Promise.all(fullUsers)
+    if (!promises) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to get user data',
+      })
+    }
+    return promises
   }),
+
+  findUserById: protectedProcedure
+    .input(z.object({ id: z.string().nullish() }))
+    .query(async ({ input, ctx }) => {
+      if (!input.id) {
+        return undefined
+      }
+      return await ctx.prisma.user.findUnique({
+        where: {
+          id: input.id,
+        },
+      })
+    }),
 
   addWhitelistedUser: protectedProcedure
     .input(

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -53,6 +53,7 @@ export const userRouter = createTRPCRouter({
         })
       }
     }),
+
   deleteManyWhitelistedUsers: protectedProcedure
     .input(z.object({ ids: z.array(z.string()) }))
     .mutation(async ({ input, ctx }) => {
@@ -70,6 +71,7 @@ export const userRouter = createTRPCRouter({
         })
       }
     }),
+
   updateUserEmailPreference: protectedProcedure
     .input(z.object({ ids: z.array(z.string()) }))
     .mutation(async ({ input, ctx }) => {
@@ -116,13 +118,14 @@ export const userRouter = createTRPCRouter({
       if (!wuser.userId) {
         return wuser
       }
-      return (
-        (await ctx.prisma.user.findUnique({
-          where: {
-            id: wuser.userId,
-          },
-        })) || wuser
-      )
+
+      const fullUser = await ctx.prisma.user.findUnique({
+        where: {
+          id: wuser.userId,
+        },
+      })
+
+      return fullUser || wuser
     })
 
     const promises = await Promise.all(fullUsers)


### PR DESCRIPTION
## Summary

All whitelisted users are now displayed on the admin list instead of just the logged-in users. The `getAllUsers` procedure has been modified to return the WhitelistedUser if the User does not exist.

The InviteAdminBar now refetches the admin list once a user is added to account for this.

Closes #152

## Changes

- Get all invited users from the database to display on the admin list
- Update InviteAdminBar and AdminListTable functionality

## Screenshots

![image](https://user-images.githubusercontent.com/111911351/235330082-d580d3b9-0a3c-4c91-a8a7-ec50d56a6e33.png)
