### PR TITLE
Aggregate Total Market Value for MongoDB Trigger

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -220,3 +220,10 @@ model Signatory {
   twitter     String?
   shouldEmail Boolean
 }
+
+model AggregatedTotalMarketVal {
+  id             String @id @default(auto()) @map("_id") @db.ObjectId
+  sector         Sector
+  totalMarketVal Float
+  year           Int?
+}

--- a/src/components/chart/LandingDonutChart.tsx
+++ b/src/components/chart/LandingDonutChart.tsx
@@ -20,10 +20,13 @@ interface companySectorCount {
  * @returns - Donut chart of company net asset value by sector
  */
 const LandingDonutChart: FC = () => {
-  const source = api.company.getNetAssetValBySector.useQuery(undefined, {
-    refetchOnWindowFocus: false,
-    staleTime: Infinity,
-  })
+  const source = api.aggregation.getTotalMarketValBySector.useQuery(
+    { year: null },
+    {
+      refetchOnWindowFocus: false,
+      staleTime: Infinity,
+    },
+  )
 
   if (!source.data)
     return (
@@ -32,12 +35,10 @@ const LandingDonutChart: FC = () => {
       </div>
     )
 
-  const pairs: companySectorCount[] = source.data
-    .filter((data) => data._sum.netAssetVal !== null)
-    .map((data) => ({
-      label: data.sector as Sector,
-      count: data._sum.netAssetVal as number,
-    }))
+  const pairs: companySectorCount[] = source.data.map((data) => ({
+    label: data.sector,
+    count: data.totalMarketVal,
+  }))
 
   /**
    * Aggregates all sectors under a threshold, including any none-type sectors, into a category labeled "OTHER"

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -4,6 +4,7 @@ import { companyRouter } from './routers/company'
 import { esgRouter } from './routers/esg'
 import { userRouter } from './routers/user'
 import { signatoryRouter } from './routers/signatory'
+import { aggregationRouter } from './routers/aggregation'
 
 /**
  * This is the primary router for your server.
@@ -16,6 +17,7 @@ export const appRouter = createTRPCRouter({
   cronjob: esgRouter,
   request: requestRouter,
   signatory: signatoryRouter,
+  aggregation: aggregationRouter,
 })
 
 // export type definition of API

--- a/src/server/api/routers/aggregation.ts
+++ b/src/server/api/routers/aggregation.ts
@@ -1,0 +1,98 @@
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import type { AggregatedTotalMarketVal } from '@prisma/client'
+
+import { createTRPCRouter, publicProcedure } from '../trpc'
+
+export const aggregationRouter = createTRPCRouter({
+  aggregateTotalMarketValBySector: publicProcedure
+    .input(
+      z.object({
+        year: z.number().nullable(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const aggregated = await ctx.prisma.investment.aggregateRaw({
+        pipeline: [
+          {
+            $match: {
+              year: input.year || { $exists: true },
+            },
+          },
+          {
+            $lookup: {
+              from: 'Company',
+              localField: 'companyId',
+              foreignField: '_id',
+              as: 'companyInfo',
+            },
+          },
+          {
+            $group: {
+              _id: '$companyInfo.sector',
+              totalMarketVal: { $sum: '$marketVal' },
+            },
+          },
+          {
+            $unwind: '$_id',
+          },
+          {
+            $project: {
+              _id: 0,
+              sector: '$_id',
+              totalMarketVal: 1,
+            },
+          },
+          {
+            $set: {
+              year: input.year || null,
+            },
+          },
+        ],
+      })
+
+      if (!aggregated) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Error aggregating net asset value by sector',
+        })
+      }
+
+      const createMany = await ctx.prisma.aggregatedTotalMarketVal.createMany({
+        data: aggregated as unknown as AggregatedTotalMarketVal[],
+      })
+
+      if (!createMany) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Error creating aggregated total market value by sector',
+        })
+      }
+    }),
+  getTotalMarketValBySector: publicProcedure
+    .input(
+      z.object({
+        year: z.number().nullable(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const aggregated = await ctx.prisma.aggregatedTotalMarketVal.findMany({
+        where: {
+          year: input.year || null,
+        },
+        select: {
+          sector: true,
+          totalMarketVal: true,
+        },
+      })
+
+      if (!aggregated) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Error fetching aggregated total market value by sector',
+        })
+      }
+
+      return aggregated
+    }),
+})


### PR DESCRIPTION
## Summary

**WIP** Aggregate investment total market value information for faster data fetching on landing page. 
- [ ] To-do: Add trigger in MongoDB 

## Notes
- Chose to save the query in this repo rather than having it in the trigger and invoking this as an API endpoint, this way we keep mostly monorepo
- Chose to add a `year` parameter, just in case we want to have a year toggle in the future 

## Changes

- Added aggregation query 
- Added new fetch data query (should probably delete the old one as well) 
- Added new schema 

```
model AggregatedTotalMarketVal {
  id             String @id @default(auto()) @map("_id") @db.ObjectId
  sector         Sector
  totalMarketVal Float
  year           Int?
}
```