### PR TITLE
Updating Tare Page tooltip and Carbon Accounting Contentful

### DIFF
--- a/src/components/chart/EmissionBarChart.tsx
+++ b/src/components/chart/EmissionBarChart.tsx
@@ -2,6 +2,8 @@ import type { FC } from 'react'
 import dynamic from 'next/dynamic'
 import type { Emission } from '@prisma/client'
 
+import { assetAmountToString } from '../../utils/helpers'
+
 const Chart = dynamic(() => import('react-apexcharts'), { ssr: false })
 
 interface EmissionBarChartProps {
@@ -38,7 +40,8 @@ const EmissionBarChart: FC<EmissionBarChartProps> = ({ emissionData }) => {
   const options = {
     tooltip: {
       y: {
-        formatter: (value: number) => `${value}k metric tons CO2`,
+        formatter: (value: number) =>
+          `${assetAmountToString(value * 1000)} metric tons CO2`,
       },
     },
     plotOptions: {

--- a/src/components/chart/EmissionBarChart.tsx
+++ b/src/components/chart/EmissionBarChart.tsx
@@ -38,7 +38,7 @@ const EmissionBarChart: FC<EmissionBarChartProps> = ({ emissionData }) => {
   const options = {
     tooltip: {
       y: {
-        formatter: (value: number) => `${value}k metric tons CO2e`,
+        formatter: (value: number) => `${value}k metric tons CO2`,
       },
     },
     plotOptions: {

--- a/src/components/chart/EmissionBarChart.tsx
+++ b/src/components/chart/EmissionBarChart.tsx
@@ -38,8 +38,7 @@ const EmissionBarChart: FC<EmissionBarChartProps> = ({ emissionData }) => {
   const options = {
     tooltip: {
       y: {
-        formatter: (value: number) =>
-          `${(value / 1000).toFixed(3)} Thousands of metric tons CO2e`,
+        formatter: (value: number) => `${value}k metric tons CO2e`,
       },
     },
     plotOptions: {

--- a/src/components/chart/EmissionBarChart.tsx
+++ b/src/components/chart/EmissionBarChart.tsx
@@ -38,7 +38,8 @@ const EmissionBarChart: FC<EmissionBarChartProps> = ({ emissionData }) => {
   const options = {
     tooltip: {
       y: {
-        formatter: (value: number) => `${value} Metric tons CO2e`,
+        formatter: (value: number) =>
+          `${(value / 1000).toFixed(3)} Thousands of metric tons CO2e`,
       },
     },
     plotOptions: {

--- a/src/pages/company/[id].tsx
+++ b/src/pages/company/[id].tsx
@@ -123,6 +123,9 @@ const Company: FC<CompanyDetailsProps> = ({
   const { company, sectorEntry, industryEntry } = data
   const chartDirections = getChartDirections(company)
 
+  console.log('Test')
+  console.log(company.name)
+
   return (
     <>
       <div className="mt-6 ml-8">


### PR DESCRIPTION
## Summary

This PR updates the Tar page emissions chart tooltip to thousands of metric tons of CO2, and also updates the carbon accounting blurb for Exxon specifically. 

Closes #218 

## Changes

- break up the blurb into an info & citation section
- use both for everything but exon
- for exon just use the info and have a custom citation in the code base

## Screenshots
<img width="650" alt="image" src="https://github.com/toriis-portal/toriis/assets/61480751/ae51844b-94f5-4e22-8807-1db93ec3eab7">

Zoomed out for screenshot:
<img width="1440" alt="image" src="https://github.com/toriis-portal/toriis/assets/61480751/0391e8bb-37bb-489d-8ffd-b3f26987adc1">
<img width="1440" alt="image" src="https://github.com/toriis-portal/toriis/assets/61480751/912fffb1-058e-4c42-bd71-56a76ad8f313">
