### PR TITLE
Changed postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev",
-    "postinstall": "prisma generate; husky install",
+    "postinstall": "prisma generate && husky install",
     "lint": "next lint",
     "start": "next start",
     "format": "yarn prettier --write . --plugin=prettier-plugin-tailwindcss",

--- a/src/components/card/CompanyCard.tsx
+++ b/src/components/card/CompanyCard.tsx
@@ -68,7 +68,7 @@ const CompanyCard: FC<CardProps> = ({ companyInfo }) => {
               <div className="col-span-1 col-start-1 row-span-1 row-start-3 self-center">
                 <Tag title="industry" className="bg-lightBlue text-black" />
               </div>
-              <p className="text-wrap col-span-1 col-start-2 row-span-1 row-start-3">
+              <p className="col-span-1 col-start-2 row-span-1 row-start-3 text-wrap">
                 {companyInfo.company.industry
                   ? companyInfo.company.industry
                   : 'None specified'}

--- a/src/server/api/routers/request.ts
+++ b/src/server/api/routers/request.ts
@@ -203,7 +203,9 @@ export const requestRouter = createTRPCRouter({
         })
       }
       const targetDataset = datasetEnum[request.dataset]
-      const targetItems = request.updates.map((update) => update.id)
+      const targetItems = (request.updates as { id: string }[]).map(
+        (update) => update.id,
+      )
 
       const originalData = await ctx.prisma.$runCommandRaw({
         find: targetDataset,


### PR DESCRIPTION
## Summary

1.  postinstall script that generates Prisma client and installs husky were separated in a manner that was incompatible with Windows and caused errors in yarn run dev in package.json
2. eslint issues with not specific types in request.ts in the routers

## Changes

- Changed the splitting of commands from "prisma generate; husky install" to "prisma generate && husky install"
- Explicitly mentioned type of targetItems in routers/requests.ts line 206

